### PR TITLE
feat(OH-74): 회원가입, 로그인 기능 및 JWT 토큰 인증 로직 개발

### DIFF
--- a/src/main/java/kr/co/onehunnit/onhunnit/OnhunnitApplication.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/OnhunnitApplication.java
@@ -2,7 +2,9 @@ package kr.co.onehunnit.onhunnit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OnhunnitApplication {
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
@@ -4,23 +4,34 @@ import java.util.Collections;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kr.co.onehunnit.onhunnit.config.jwt.JwtAccessDeniedHandler;
+import kr.co.onehunnit.onhunnit.config.jwt.JwtAuthenticationEntryPoint;
+import kr.co.onehunnit.onhunnit.config.jwt.JwtAuthenticationFilter;
+import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,7 +40,7 @@ public class SecurityConfig {
 				@Override
 				public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
 					CorsConfiguration config = new CorsConfiguration();
-					config.setAllowedOrigins(Collections.singletonList("*"));
+					config.setAllowedOrigins(Collections.singletonList("*")); //테스트를 위해 일단 전체 허용
 					config.setAllowedMethods(Collections.singletonList("*"));
 					config.setAllowCredentials(true);
 					config.setAllowedHeaders(Collections.singletonList("*"));
@@ -37,20 +48,23 @@ public class SecurityConfig {
 					return config;
 				}
 			}))
-			// .exceptionHandling(exception -> exception
-			// 	.accessDeniedHandler(jwtAccessDeniedHandler)
-			// 	.authenticationEntryPoint(jwtAuthenticationEntryPoint)) //예외처리
+			.csrf(AbstractHttpConfigurer::disable)
+			 .exceptionHandling(exception -> exception
+			 	.accessDeniedHandler(jwtAccessDeniedHandler)
+			 	.authenticationEntryPoint(jwtAuthenticationEntryPoint))
 
 			.sessionManagement(session -> session
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션 사용 안함
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-			// .authorizeHttpRequests(request -> request
-				// .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-				// .requestMatchers("/api/user/login").permitAll()
-				// .requestMatchers("/api/user/join").permitAll()
-				// .anyRequest().authenticated()) //나머지 요청은 인증 필요
+			.authorizeHttpRequests(request -> request
+				.requestMatchers("/api/oauth/refresh-token").permitAll()
+				.requestMatchers("/api/oauth/kakao").permitAll()
+				.requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+				.requestMatchers("/api/user/sign-up").permitAll()
+				.requestMatchers("/api/user/sign-in").permitAll()
+				.anyRequest().authenticated()) //나머지 요청은 인증 필요
 
-			// .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
 		;
 
 		return http.build();

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
@@ -8,6 +8,12 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
 	POSTS_EMPTY_TITLE(400, "제목을 입력하세요.", 417),
+	ACCOUNT_DATA_ERROR(400, "양식에 맞는 값을 입력해주세요.", 418),
+	ACCOUNT_DUPLICATED_ERROR(400, "이미 존재하는 이메일입니다.", 419),
+
+
+
+
 	INVALID_TOKEN(401, "유효하지 않은 토큰입니다.", 1001),
 	UNKNOWN_ERROR(401, "토큰이 존재하지 않습니다.", 1002),
 	WRONG_TYPE_TOKEN(401, "변조된 토큰입니다.", 1003),

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package kr.co.onehunnit.onhunnit.config.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        //권한 없는데 접근할 때 403
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package kr.co.onehunnit.onhunnit.config.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+
+    }
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package kr.co.onehunnit.onhunnit.config.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		String token = resolveToken((HttpServletRequest) request);
+
+		try {
+			if (token != null && jwtTokenProvider.validateToken(token)) {
+				Authentication authentication = jwtTokenProvider.getAuthentication(token);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (ExpiredJwtException e) {
+			throw new ApiException(ErrorCode.EXPIRED_TOKEN);
+		} catch (UnsupportedJwtException e) {
+			throw new ApiException(ErrorCode.UNSUPPORTED_TOKEN);
+		} catch (Exception e) {
+			throw new ApiException(ErrorCode.UNKNOWN_ERROR);
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader("Authorization");
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtTokenProvider.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtTokenProvider {
 
 	private final Key key;
-	//ToDo
+	//ToDo 만료 기간 수정 1시간 -> 일주일
 	private final int ACCESSTOKEN_EXPIRATION_TIME = 1000 * 60 * 60; //1시간
 	private final int REFRESHTOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 21;
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtTokenProvider.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtTokenProvider {
 
 	private final Key key;
+	//ToDo
 	private final int ACCESSTOKEN_EXPIRATION_TIME = 1000 * 60 * 60; //1시간
 	private final int REFRESHTOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 21;
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,138 @@
+package kr.co.onehunnit.onhunnit.config.jwt;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.dto.token.TokenInfoDto;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	private final Key key;
+	private final int ACCESSTOKEN_EXPIRATION_TIME = 1000 * 60 * 60; //1시간
+	private final int REFRESHTOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 21;
+
+	public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+		this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+	}
+
+	public TokenInfoDto generateToken(Authentication authentication) {
+		String accessToken = createAccessToken(authentication);
+		String refreshToken = createRefreshToken(authentication);
+
+		return TokenInfoDto.builder()
+			.grantType("Bearer")
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	private String getAuthorities(Authentication authentication) {
+		return authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+	}
+
+	private String createAccessToken(Authentication authentication) {
+		long now = (new Date()).getTime();
+		Date accessTokenExpiration = new Date(now + ACCESSTOKEN_EXPIRATION_TIME); //1시간
+
+		return Jwts.builder()
+			.setSubject(authentication.getName())
+			.claim("auth", getAuthorities(authentication))
+			.setExpiration(accessTokenExpiration)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	private String createRefreshToken(Authentication authentication) {
+		long now = (new Date()).getTime();
+		Date refreshTokenExpiration = new Date(now + REFRESHTOKEN_EXPIRATION_TIME); //21일
+
+		return Jwts.builder()
+			.setSubject(authentication.getName())
+			.claim("auth", getAuthorities(authentication))
+			.setExpiration(refreshTokenExpiration)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public Authentication getAuthentication(String accessToken) {
+		Claims claims = parseClaims(accessToken);
+
+		if (claims.get("auth") == null) {
+			throw new ApiException(ErrorCode.ACCESS_DENIED);
+		}
+
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get("auth").toString().split(","))
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+
+		UserDetails principal = new User(claims.getSubject(), "", authorities);
+		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+	}
+
+	public boolean validateToken(String accessToken) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken);
+			return true;
+		} catch (SecurityException | MalformedJwtException e) {
+			throw new ApiException(ErrorCode.INVALID_TOKEN);
+		} catch (ExpiredJwtException e) {
+			throw new ApiException(ErrorCode.EXPIRED_TOKEN);
+		} catch (UnsupportedJwtException e) {
+			throw new ApiException(ErrorCode.UNSUPPORTED_TOKEN);
+		} catch (IllegalArgumentException e) {
+			throw new ApiException(ErrorCode.UNKNOWN_ERROR);
+		}
+	}
+
+	public String extractUsernameFromJwt(String token) {
+		if (token.startsWith("Bearer ")) {
+			String resolvedToken = token.substring(7).trim();
+			Claims claims = parseClaims(resolvedToken);
+			return claims.getSubject();
+		}
+
+		return null;
+	}
+
+	private Claims parseClaims(String accessToken) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(accessToken)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new ApiException(ErrorCode.EXPIRED_TOKEN);
+		}
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
@@ -1,0 +1,35 @@
+package kr.co.onehunnit.onhunnit.controller;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.config.response.ResponseDto;
+import kr.co.onehunnit.onhunnit.config.response.ResponseUtil;
+import kr.co.onehunnit.onhunnit.dto.account.AccountRequestDto;
+import kr.co.onehunnit.onhunnit.service.AccountService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/accounts")
+@Validated
+public class AccountController {
+
+	private final AccountService accountService;
+
+	@PostMapping("/sign-up")
+	public ResponseDto<Long> signUp(@RequestBody AccountRequestDto.SignUp requestDto, BindingResult bindingResult) {
+		if (bindingResult.hasErrors()) {
+			throw new ApiException(ErrorCode.ACCOUNT_DATA_ERROR);
+		}
+
+		return ResponseUtil.SUCCESS("회원가입에 성공하였습니다.", accountService.signUp(requestDto));
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/accounts")
 @Validated
-//Todo
+//Todo /api/accounts/me jwt를 가지고 인증된 사용자의 정보 가져오는 api 필요
 public class AccountController {
 
 	private final AccountService accountService;

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/accounts")
 @Validated
+//Todo
 public class AccountController {
 
 	private final AccountService accountService;

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
@@ -1,10 +1,16 @@
 package kr.co.onehunnit.onhunnit.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import kr.co.onehunnit.onhunnit.config.response.ResponseDto;
+import kr.co.onehunnit.onhunnit.config.response.ResponseUtil;
+import kr.co.onehunnit.onhunnit.dto.token.RefreshTokenDto;
+import kr.co.onehunnit.onhunnit.dto.token.TokenInfoDto;
 import kr.co.onehunnit.onhunnit.service.OAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,16 +23,14 @@ public class OAuthController {
 
 	private final OAuthService oAuthService;
 
-	// @GetMapping("/kakao")
-	// public ResponseDto<TokenDto> kakaoCallback(@RequestParam(name = "code") String code) {
-	// 	oAuthService.kakaoOAuthLogin(code);
-	// 	return ResponseUtil.SUCCESS("카카오 로그인에 성공하였습니다.", new TokenDto());
-	// }
-
 	@GetMapping("/kakao")
-	public void test(@RequestParam(name = "authorizationCode") String authorizationCode) {
-		oAuthService.kakaoOAuthLogin(authorizationCode);
+	public ResponseDto<TokenInfoDto> kakaoCallback(@RequestParam(name = "authorizationCode") String code) {
+		return ResponseUtil.SUCCESS("카카오 로그인에 성공하였습니다.", oAuthService.kakaoOAuthLogin(code));
 	}
 
+	@PostMapping("/refresh-token")
+	public ResponseDto<TokenInfoDto> reGenerateAccessToken(@RequestBody RefreshTokenDto refreshTokenDto) {
+		return ResponseUtil.SUCCESS("토큰을 재발급하였습니다.", oAuthService.reGenerateAccessToken(refreshTokenDto));
+	}
 
 }

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Account.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Account.java
@@ -1,0 +1,37 @@
+package kr.co.onehunnit.onhunnit.domain.account;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Account extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String email;
+
+	private SocialService social_name;
+
+	private String name;
+
+	private String nickname;
+
+	private int age;
+
+	private String phone;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/SocialService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/SocialService.java
@@ -1,0 +1,5 @@
+package kr.co.onehunnit.onhunnit.domain.account;
+
+public enum SocialService {
+	KAKAO, APPLE
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/web/KakaoProperties.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/web/KakaoProperties.java
@@ -1,4 +1,4 @@
-package kr.co.onehunnit.onhunnit;
+package kr.co.onehunnit.onhunnit.domain.account.web;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/global/BaseTimeEntity.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/global/BaseTimeEntity.java
@@ -1,0 +1,39 @@
+package kr.co.onehunnit.onhunnit.domain.global;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	public void prePersist() {
+		LocalDateTime nowInKorea = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+		if (this.createdAt == null) {
+			this.createdAt = nowInKorea;
+		}
+		if (this.updatedAt == null) {
+			this.updatedAt = nowInKorea;
+		}
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/account/AccountRequestDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/account/AccountRequestDto.java
@@ -1,0 +1,17 @@
+package kr.co.onehunnit.onhunnit.dto.account;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+public class AccountRequestDto {
+
+	@Getter
+	@Builder
+	public static class SignUp {
+		private String email;
+		private String name;
+		private String phoneNumber;
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/token/RefreshTokenDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/token/RefreshTokenDto.java
@@ -1,0 +1,14 @@
+package kr.co.onehunnit.onhunnit.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenDto {
+
+	private String refreshToken;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/token/TokenInfoDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/token/TokenInfoDto.java
@@ -1,0 +1,16 @@
+package kr.co.onehunnit.onhunnit.dto.token;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Data
+@Builder
+public class TokenInfoDto {
+
+	private final String grantType;
+	private final String accessToken;
+	private final String refreshToken;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/AccountRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/AccountRepository.java
@@ -1,0 +1,17 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+	boolean existsByEmail(String email);
+
+	Optional<Account> findByNickname(String nickname);
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/AccountRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/AccountRepository.java
@@ -10,6 +10,7 @@ import kr.co.onehunnit.onhunnit.domain.account.Account;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
+	//ToDo
 	boolean existsByEmail(String email);
 
 	Optional<Account> findByNickname(String nickname);

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/AccountRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/AccountRepository.java
@@ -10,7 +10,7 @@ import kr.co.onehunnit.onhunnit.domain.account.Account;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
-	//ToDo
+	//ToDo provider로 가져오는 메서드 필요
 	boolean existsByEmail(String email);
 
 	Optional<Account> findByNickname(String nickname);

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
@@ -1,0 +1,33 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+import kr.co.onehunnit.onhunnit.dto.account.AccountRequestDto;
+import kr.co.onehunnit.onhunnit.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AccountService {
+
+	private final AccountRepository accountRepository;
+
+	public Long signUp(AccountRequestDto.SignUp requestDto) {
+		if (accountRepository.existsByEmail(requestDto.getEmail())) {
+			throw new ApiException(ErrorCode.ACCOUNT_DUPLICATED_ERROR);
+		}
+
+		Account account = Account.builder()
+			.email(requestDto.getEmail())
+			.name(requestDto.getName())
+			.phone(requestDto.getPhoneNumber())
+			.build();
+
+		return accountRepository.save(account).getId();
+	}
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
@@ -17,7 +17,7 @@ public class AccountService {
 
 	private final AccountRepository accountRepository;
 
-	//ToDo
+	//ToDo 회원가입 명세서에 맞게 수정
 	public Long signUp(AccountRequestDto.SignUp requestDto) {
 		if (accountRepository.existsByEmail(requestDto.getEmail())) {
 			throw new ApiException(ErrorCode.ACCOUNT_DUPLICATED_ERROR);

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
@@ -17,6 +17,7 @@ public class AccountService {
 
 	private final AccountRepository accountRepository;
 
+	//ToDo
 	public Long signUp(AccountRequestDto.SignUp requestDto) {
 		if (accountRepository.existsByEmail(requestDto.getEmail())) {
 			throw new ApiException(ErrorCode.ACCOUNT_DUPLICATED_ERROR);

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/KakaoSocialService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/KakaoSocialService.java
@@ -15,7 +15,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import kr.co.onehunnit.onhunnit.KakaoProperties;
+import kr.co.onehunnit.onhunnit.domain.account.web.KakaoProperties;
 import kr.co.onehunnit.onhunnit.config.exception.ApiException;
 import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
@@ -1,10 +1,23 @@
 package kr.co.onehunnit.onhunnit.service;
 
 import java.util.HashMap;
+import java.util.Optional;
 
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import kr.co.onehunnit.onhunnit.dto.token.TokenDto;
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+import kr.co.onehunnit.onhunnit.domain.account.SocialService;
+import kr.co.onehunnit.onhunnit.dto.token.RefreshTokenDto;
+import kr.co.onehunnit.onhunnit.dto.token.TokenInfoDto;
+import kr.co.onehunnit.onhunnit.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -12,9 +25,41 @@ import lombok.RequiredArgsConstructor;
 public class OAuthService {
 
 	private final KakaoSocialService kakaoSocialService;
+	private final AccountRepository accountRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final AuthenticationManager authenticationManager;
 
-	public void kakaoOAuthLogin(String authorizationCode) {
-		String kakaoToken = kakaoSocialService.getKakaoAccessToken(authorizationCode);
-		HashMap<String, Object> userInfo = kakaoSocialService.getKakaoUserInfo(kakaoToken);
+	public TokenInfoDto kakaoOAuthLogin(String authorizationCode) {
+		String kakaoAccessToken = kakaoSocialService.getKakaoAccessToken(authorizationCode);
+		HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(kakaoAccessToken);
+		String userNickname = kakaoUserInfo.get("nickname").toString();
+
+		Optional<Account> account = accountRepository.findByNickname(userNickname);
+		if (account.isEmpty()) {
+			Account newAccount = Account.builder()
+				.social_name(SocialService.KAKAO)
+				.nickname(kakaoUserInfo.get("nickname").toString())
+				.build();
+			accountRepository.save(newAccount);
+			return null;
+		}
+
+		return jwtTokenProvider.generateToken(getAuthentication(userNickname));
+	}
+
+	public TokenInfoDto reGenerateAccessToken(RefreshTokenDto refreshTokenDto) {
+		String refreshToken = refreshTokenDto.getRefreshToken();
+		if (!jwtTokenProvider.validateToken(refreshToken)) {
+			throw new ApiException(ErrorCode.INVALID_TOKEN);
+		}
+
+		String userNickname = jwtTokenProvider.extractUsernameFromJwt(refreshToken);
+		return jwtTokenProvider.generateToken(getAuthentication(userNickname));
+	}
+
+	private static Authentication getAuthentication(String userNickname) {
+		Authentication authentication =	new UsernamePasswordAuthenticationToken(userNickname, "");
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		return authentication;
 	}
 }

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
@@ -31,6 +31,7 @@ public class OAuthService {
 
 	public TokenInfoDto kakaoOAuthLogin(String authorizationCode) {
 		String kakaoAccessToken = kakaoSocialService.getKakaoAccessToken(authorizationCode);
+		//ToDo
 		HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(kakaoAccessToken);
 		String userNickname = kakaoUserInfo.get("nickname").toString();
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
@@ -31,7 +31,7 @@ public class OAuthService {
 
 	public TokenInfoDto kakaoOAuthLogin(String authorizationCode) {
 		String kakaoAccessToken = kakaoSocialService.getKakaoAccessToken(authorizationCode);
-		//ToDo
+		//ToDo 로그인 명세에 맞게 수정 필요 Provider와 email을 사용하여 식별
 		HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(kakaoAccessToken);
 		String userNickname = kakaoUserInfo.get("nickname").toString();
 


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OH-74

## 작업 내용

- 회원가입 
    카카오 소셜로그인 처음 진행 시 DB에 Account 데이터 추가
- 로그인 
    카카오 소셜로그인 진행 시, DB에 Account 데이터가 있으면 JWT 토큰 발급.
   액세스 토큰의 만료기간은 1시간, 리프레시 토큰의 만료기간은 21일로 설정
- 액세스 토큰 재발급 API
    전달받은 리프레시 토큰을 이용하여 액세스 토큰 재발급
- BaseTimeEntity 클래스 생성 
    테이블마다 생성일자와 수정일자를 추가하기 위한 추상 클래스

## 참고사항
