### PR TITLE
feat(OH-141): 보호자 등록 요청 / 수락 API 개발

### DIFF
--- a/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
@@ -57,11 +57,11 @@ public class SecurityConfig {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
 			.authorizeHttpRequests(request -> request
-				.requestMatchers("/api/oauth/refresh-token").permitAll()
-				.requestMatchers("/api/oauth/kakao").permitAll()
+				.requestMatchers("/oauth/refresh-token").permitAll()
+				.requestMatchers("/oauth/kakao").permitAll()
 				.requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-				.requestMatchers("/api/user/sign-up").permitAll()
-				.requestMatchers("/api/user/sign-in").permitAll()
+				.requestMatchers("/user/sign-up").permitAll()
+				.requestMatchers("/user/sign-in").permitAll()
 				.anyRequest().authenticated()) //나머지 요청은 인증 필요
 
 			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/SwaggerConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/SwaggerConfig.java
@@ -30,7 +30,7 @@ public class SwaggerConfig {
 
 	private Info apiInfo() {
 		return new Info()
-			.title("PilBom API Document")
+			.title("FillBom API Document")
 			.description("필봄 API 문서")
 			.version("1.0.0");
 	}

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
@@ -11,8 +11,11 @@ public enum ErrorCode {
 	ACCOUNT_DATA_ERROR(400, "양식에 맞는 값을 입력해주세요.", 418),
 	ACCOUNT_DUPLICATED_ERROR(400, "이미 존재하는 이메일입니다.", 419),
 
+	NOT_EXIST_CAREGIVER(400, "보호자 정보가 존재하지 않습니다.", 601),
 
+	NOT_EXIST_PATIENT(400, "환자 정보가 존재하지 않습니다.", 701),
 
+	NOT_EXIST_ACCOUNT(400, "계정 정보가 존재하지 않습니다.", 801),
 
 	INVALID_TOKEN(401, "유효하지 않은 토큰입니다.", 1001),
 	UNKNOWN_ERROR(401, "토큰이 존재하지 않습니다.", 1002),
@@ -25,6 +28,7 @@ public enum ErrorCode {
 	FAILED_TO_RETRIEVE_KAKAO_ACCESS_TOKEN(401, "카카오로부터 AccessToken 발급에 실패했습니다.", 1009),
 	RESPONSE_CODE_ERROR(401, "인가 코드 요청에 따른 응답 코드가 200이 아닙니다.", 1010),
 	FAILED_TO_RETRIEVE_KAKAO_USER_INFO(401, "카카오로부터 유저 정보 발급에 실패했습니다.", 1011),
+	NO_TOKEN_ACCOUNT(401, "토큰에 해당하는 계정 정보가 없습니다.", 1012),
 	;
 
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/AccountController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/accounts")
+@RequestMapping("/accounts")
 @Validated
 //Todo /api/accounts/me jwt를 가지고 인증된 사용자의 정보 가져오는 api 필요
 public class AccountController {

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/oauth")
+@RequestMapping("/oauth")
 public class OAuthController {
 
 	private final OAuthService oAuthService;

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/PatientController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/PatientController.java
@@ -1,0 +1,27 @@
+package kr.co.onehunnit.onhunnit.controller;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.onehunnit.onhunnit.config.response.ResponseDto;
+import kr.co.onehunnit.onhunnit.config.response.ResponseUtil;
+import kr.co.onehunnit.onhunnit.service.PatientService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/patient")
+public class PatientController {
+
+	private final PatientService patientService;
+
+	@PostMapping("/registration/caregivers/{caregiver_id}")
+	public ResponseDto<Long> registerCaregiver(HttpServletRequest request, @PathVariable Long caregiver_id) {
+		return ResponseUtil.SUCCESS("보호자 등록에 성공하였습니다.",
+			patientService.registerCaregiver(request.getHeader("Authorization"), caregiver_id));
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Account.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Account.java
@@ -1,7 +1,8 @@
 package kr.co.onehunnit.onhunnit.domain.account;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,7 +25,10 @@ public class Account extends BaseTimeEntity {
 
 	private String email;
 
-	private SocialService social_name;
+	@Enumerated(value = EnumType.STRING)
+	private Provider provider;
+
+	private String profile_image;
 
 	private String name;
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Caregiver.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Caregiver.java
@@ -1,0 +1,47 @@
+package kr.co.onehunnit.onhunnit.domain.account;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
+import kr.co.onehunnit.onhunnit.domain.patient_Caregiver.PatientCaregiver;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class Caregiver extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "caregiver_id")
+	private Long id;
+
+	private String relationship;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "account_id")
+	private Account account;
+
+	@OneToMany(mappedBy = "caregiver")
+	private List<PatientCaregiver> patientCaregiverList = new ArrayList<>();
+
+	public void setAccount(Account account) {
+		this.account = account;
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Provider.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Provider.java
@@ -1,5 +1,5 @@
 package kr.co.onehunnit.onhunnit.domain.account;
 
-public enum SocialService {
+public enum Provider {
 	KAKAO, APPLE
 }

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/patient/Patient.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/patient/Patient.java
@@ -1,0 +1,48 @@
+package kr.co.onehunnit.onhunnit.domain.patient;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
+import kr.co.onehunnit.onhunnit.domain.patient_Caregiver.PatientCaregiver;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Patient extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "patient_id")
+	private Long id;
+
+	@OneToMany(mappedBy = "patient")
+	private List<PatientCaregiver> patientCaregiverList = new ArrayList<>();
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "account_id")
+	private Account account;
+
+	public void setAccount(Account account) {
+		this.account = account;
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/patient_Caregiver/PatientCaregiver.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/patient_Caregiver/PatientCaregiver.java
@@ -1,0 +1,40 @@
+package kr.co.onehunnit.onhunnit.domain.patient_Caregiver;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.onehunnit.onhunnit.domain.account.Caregiver;
+import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Entity
+public class PatientCaregiver extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "patient_caregiver_id")
+	private Long id;
+
+	private boolean is_accepted;
+
+	@ManyToOne
+	@JoinColumn(name = "patient_id")
+	private Patient patient;
+
+	@ManyToOne
+	@JoinColumn(name = "caregiver_id")
+	private Caregiver caregiver;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/CaregiverRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/CaregiverRepository.java
@@ -1,0 +1,11 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.account.Caregiver;
+
+@Repository
+public interface CaregiverRepository extends JpaRepository<Caregiver, Long> {
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/PatientCaregiverRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/PatientCaregiverRepository.java
@@ -1,0 +1,10 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.patient_Caregiver.PatientCaregiver;
+
+@Repository
+public interface PatientCaregiverRepository extends JpaRepository<PatientCaregiver, Long> {
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/PatientRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/PatientRepository.java
@@ -1,0 +1,15 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+
+@Repository
+public interface PatientRepository extends JpaRepository<Patient, Long> {
+
+	Optional<Patient> findByAccount_Id(Long id);
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.onehunnit.onhunnit.config.exception.ApiException;
 import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
 import kr.co.onehunnit.onhunnit.domain.account.Account;
 import kr.co.onehunnit.onhunnit.dto.account.AccountRequestDto;
 import kr.co.onehunnit.onhunnit.repository.AccountRepository;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class AccountService {
 
 	private final AccountRepository accountRepository;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	//ToDo 회원가입 명세서에 맞게 수정
 	public Long signUp(AccountRequestDto.SignUp requestDto) {
@@ -31,4 +33,9 @@ public class AccountService {
 
 		return accountRepository.save(account).getId();
 	}
+
+	public Account getAccountByToken(String accessToken) {
+		return accountRepository.findByNickname(jwtTokenProvider.extractUsernameFromJwt(accessToken)).orElseThrow(() -> new ApiException(ErrorCode.NO_TOKEN_ACCOUNT));
+	}
+
 }

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
@@ -1,12 +1,14 @@
 package kr.co.onehunnit.onhunnit.service;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Optional;
 
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +16,7 @@ import kr.co.onehunnit.onhunnit.config.exception.ApiException;
 import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
 import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
 import kr.co.onehunnit.onhunnit.domain.account.Account;
-import kr.co.onehunnit.onhunnit.domain.account.SocialService;
+import kr.co.onehunnit.onhunnit.domain.account.Provider;
 import kr.co.onehunnit.onhunnit.dto.token.RefreshTokenDto;
 import kr.co.onehunnit.onhunnit.dto.token.TokenInfoDto;
 import kr.co.onehunnit.onhunnit.repository.AccountRepository;
@@ -27,7 +29,6 @@ public class OAuthService {
 	private final KakaoSocialService kakaoSocialService;
 	private final AccountRepository accountRepository;
 	private final JwtTokenProvider jwtTokenProvider;
-	private final AuthenticationManager authenticationManager;
 
 	public TokenInfoDto kakaoOAuthLogin(String authorizationCode) {
 		String kakaoAccessToken = kakaoSocialService.getKakaoAccessToken(authorizationCode);
@@ -38,7 +39,7 @@ public class OAuthService {
 		Optional<Account> account = accountRepository.findByNickname(userNickname);
 		if (account.isEmpty()) {
 			Account newAccount = Account.builder()
-				.social_name(SocialService.KAKAO)
+				.provider(Provider.KAKAO)
 				.nickname(kakaoUserInfo.get("nickname").toString())
 				.build();
 			accountRepository.save(newAccount);
@@ -58,9 +59,13 @@ public class OAuthService {
 		return jwtTokenProvider.generateToken(getAuthentication(userNickname));
 	}
 
-	private static Authentication getAuthentication(String userNickname) {
-		Authentication authentication =	new UsernamePasswordAuthenticationToken(userNickname, "");
+	private Authentication getAuthentication(String userNickname) {
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(userNickname, null, authorities);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 		return authentication;
 	}
+
 }

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/PatientService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/PatientService.java
@@ -1,0 +1,40 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+import kr.co.onehunnit.onhunnit.domain.account.Caregiver;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import kr.co.onehunnit.onhunnit.domain.patient_Caregiver.PatientCaregiver;
+import kr.co.onehunnit.onhunnit.repository.CaregiverRepository;
+import kr.co.onehunnit.onhunnit.repository.PatientCaregiverRepository;
+import kr.co.onehunnit.onhunnit.repository.PatientRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class PatientService {
+
+	private final PatientRepository patientRepository;
+	private final AccountService accountService;
+	private final CaregiverRepository caregiverRepository;
+	private final PatientCaregiverRepository patientCaregiverRepositㅔㅁory;
+
+	public Long registerCaregiver(String accessToken, Long caregiverId) {
+		Account account = accountService.getAccountByToken(accessToken);
+		Patient patient = patientRepository.findByAccount_Id(account.getId()).orElseThrow(() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+		Caregiver caregiver = caregiverRepository.findById(caregiverId).orElseThrow(() -> new ApiException(ErrorCode.NOT_EXIST_CAREGIVER));
+
+		PatientCaregiver patientCaregiver = new PatientCaregiver().builder()
+			.patient(patient)
+			.caregiver(caregiver)
+			.is_accepted(true)
+			.build();
+
+		return patientCaregiverRepository.save(patientCaregiver).getId();
+	}
+}


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OH-141

## 작업 내용
- 환자, 보호자, 환자-보호자 클래스 생성
- 환자가 보호자 등록 요청시 DB에 환자-보호자 데이터 추가와 동시에 is_accepted = true로 설정 
- 기본 사용자 권한을 auth 클레임에 포함하도록 수정

## 참고사항
