### PR TITLE
feat(OH-120): email + provider를 통해 유저 구분 로직 생성

### DIFF
--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
@@ -24,8 +24,8 @@ public class OAuthController {
 	private final OAuthService oAuthService;
 
 	@GetMapping("/kakao")
-	public ResponseDto<TokenInfoDto> kakaoCallback(@RequestParam(name = "authorizationCode") String code) {
-		return ResponseUtil.SUCCESS("카카오 로그인에 성공하였습니다.", oAuthService.kakaoOAuthLogin(code));
+	public ResponseDto<TokenInfoDto> kakaoLogin(@RequestParam(name = "idToken") String idToken) {
+		return ResponseUtil.SUCCESS("카카오 로그인에 성공하였습니다.", oAuthService.kakaoOAuthLogin(idToken));
 	}
 
 	@PostMapping("/refresh-token")

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/account/TokenAccountInfoDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/account/TokenAccountInfoDto.java
@@ -1,0 +1,13 @@
+package kr.co.onehunnit.onhunnit.dto.account;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenAccountInfoDto {
+
+	private String email;
+	private String provider;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/KakaoSocialService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/KakaoSocialService.java
@@ -12,117 +12,71 @@ import java.util.HashMap;
 import org.springframework.stereotype.Service;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import kr.co.onehunnit.onhunnit.domain.account.web.KakaoProperties;
 import kr.co.onehunnit.onhunnit.config.exception.ApiException;
 import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class KakaoSocialService {
 
-	private static final String KAKAO_LOGIN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
-	private static final String KAKAO_USER_INFO_REQUEST_URL = "https://kapi.kakao.com/v2/user/me";
+	private static final String KAKAO_TOKEN_INFO_URL = "https://kauth.kakao.com/oauth/tokeninfo";
 
-	private final KakaoProperties kakaoProperties;
-
-	public String getKakaoAccessToken(String authorizationCode) {
+	public HashMap<String, Object> getKakaoUserInfo(String idToken) {
 		try {
-			HttpURLConnection kakaoServerConnection = getKakaoServerConnectionForAuthorizationCode();
-			sendAuthorizationCodeToKakaoServer(kakaoServerConnection, authorizationCode);
-
+			HttpURLConnection kakaoServerConnection = getKakaoServerConnectionForTokenInfo(idToken);
 			if (kakaoServerConnection.getResponseCode() == 200) {
-				return getKakaoAccessToken(kakaoServerConnection);
-			} else {
-				throw new ApiException(ErrorCode.RESPONSE_CODE_ERROR);
+				return getKakaoTokenInfo(kakaoServerConnection);
 			}
-		} catch (IOException e) {
-			throw new ApiException(ErrorCode.FAILED_TO_RETRIEVE_KAKAO_ACCESS_TOKEN);
-		}
-	}
-
-	public HashMap<String, Object> getKakaoUserInfo(String accessToken) {
-		try {
-			HttpURLConnection kakaoServerConnection = getKakaoServerConnectionForUserInfo(accessToken);
-
-			if (kakaoServerConnection.getResponseCode() == 200) {
-				return getKakaoUserInfo(kakaoServerConnection);
-			} else {
-				throw new ApiException(ErrorCode.RESPONSE_CODE_ERROR);
-			}
+			throw new ApiException(ErrorCode.RESPONSE_CODE_ERROR);
 		} catch (IOException e) {
 			throw new ApiException(ErrorCode.FAILED_TO_RETRIEVE_KAKAO_USER_INFO);
 		}
 	}
 
-	private static HttpURLConnection getKakaoServerConnectionForUserInfo(String accessToken) throws IOException {
-		URL url = new URL(KAKAO_USER_INFO_REQUEST_URL);
+	private static HttpURLConnection getKakaoServerConnectionForTokenInfo(String idToken) throws IOException {
+		URL url = new URL(KAKAO_TOKEN_INFO_URL);
 		HttpURLConnection kakaoServerConnection = (HttpURLConnection)url.openConnection();
 		kakaoServerConnection.setRequestMethod("POST");
-		kakaoServerConnection.setRequestProperty("Authorization", "Bearer " + accessToken);
-		return kakaoServerConnection;
-	}
-
-	private static HttpURLConnection getKakaoServerConnectionForAuthorizationCode() throws IOException {
-		URL kakaoLoginRequestUrl = new URL(KAKAO_LOGIN_REQUEST_URL);
-		HttpURLConnection kakaoServerConnection = (HttpURLConnection)kakaoLoginRequestUrl.openConnection();
-		kakaoServerConnection.setRequestMethod("POST");
+		kakaoServerConnection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 		kakaoServerConnection.setDoOutput(true);
+
+		try (BufferedWriter bw = new BufferedWriter(
+			new OutputStreamWriter(kakaoServerConnection.getOutputStream(), "UTF-8"))) {
+			String requestBody = "id_token=" + idToken;
+			bw.write(requestBody);
+			bw.flush();
+		}
 		return kakaoServerConnection;
 	}
 
-	private void sendAuthorizationCodeToKakaoServer(HttpURLConnection kakaoServerConnection,
-		String authorizationCode) throws IOException {
-		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(kakaoServerConnection.getOutputStream()));
-
-		StringBuilder requestBody = new StringBuilder();
-		requestBody.append("grant_type=authorization_code");
-		requestBody.append("&client_id=" + kakaoProperties.getClientId());
-		requestBody.append("&client_secret=" + kakaoProperties.getClientSecret());
-		requestBody.append("&redirect_uri=" + kakaoProperties.getRedirectUri());
-		requestBody.append("&code=" + authorizationCode);
-
-		bw.write(requestBody.toString());
-		bw.flush();
-		bw.close();
-	}
-
-	private HashMap<String, Object> getKakaoUserInfo(HttpURLConnection kakaoServerConnection) throws IOException {
+	private HashMap<String, Object> getKakaoTokenInfo(HttpURLConnection kakaoServerConnection) throws IOException {
 		String responseBody = readResponse(kakaoServerConnection);
+		log.info("ResponseBody: {}", responseBody);
 
 		JsonElement jsonElement = JsonParser.parseString(responseBody);
-		JsonObject properties = jsonElement.getAsJsonObject().get("properties").getAsJsonObject();
-		JsonObject kakaoAccount = jsonElement.getAsJsonObject().get("kakao_account").getAsJsonObject();
-
-		String nickname = properties.getAsJsonObject().get("nickname").getAsString();
-		// String email = kakaoAccount.getAsJsonObject().get("email").getAsString();
+		String email = jsonElement.getAsJsonObject().get("email").getAsString();
+		String nickname = jsonElement.getAsJsonObject().get("nickname").getAsString();
+		String picture = jsonElement.getAsJsonObject().get("picture").getAsString();
 
 		HashMap<String, Object> kakaoUserInfo = new HashMap<>();
+		kakaoUserInfo.put("email", email);
 		kakaoUserInfo.put("nickname", nickname);
-		// kakaoUserInfo.put("email", email);
-
+		kakaoUserInfo.put("picture", picture);
 		return kakaoUserInfo;
-	}
-
-	private String getKakaoAccessToken(HttpURLConnection kakaoServerConnection) throws IOException {
-		String responseBody = readResponse(kakaoServerConnection);
-		JsonParser jsonParser = new JsonParser();
-		JsonElement jsonElement = jsonParser.parse(responseBody);
-		return jsonElement.getAsJsonObject().get("access_token").getAsString();
 	}
 
 	private String readResponse(HttpURLConnection kakaoServerConnection) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(kakaoServerConnection.getInputStream()));
 		String responseBodyInput = "";
 		StringBuilder responseBody = new StringBuilder();
-
 		while ((responseBodyInput = br.readLine()) != null) {
 			responseBody.append(responseBodyInput);
 		}
-
 		br.close();
 		return responseBody.toString();
 	}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
@@ -3,7 +3,6 @@ package kr.co.onehunnit.onhunnit.service;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Optional;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -17,6 +16,7 @@ import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
 import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
 import kr.co.onehunnit.onhunnit.domain.account.Account;
 import kr.co.onehunnit.onhunnit.domain.account.Provider;
+import kr.co.onehunnit.onhunnit.dto.account.TokenAccountInfoDto;
 import kr.co.onehunnit.onhunnit.dto.token.RefreshTokenDto;
 import kr.co.onehunnit.onhunnit.dto.token.TokenInfoDto;
 import kr.co.onehunnit.onhunnit.repository.AccountRepository;
@@ -30,40 +30,48 @@ public class OAuthService {
 	private final AccountRepository accountRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
-	public TokenInfoDto kakaoOAuthLogin(String authorizationCode) {
-		String kakaoAccessToken = kakaoSocialService.getKakaoAccessToken(authorizationCode);
-		//ToDo 로그인 명세에 맞게 수정 필요 Provider와 email을 사용하여 식별
-		HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(kakaoAccessToken);
-		String userNickname = kakaoUserInfo.get("nickname").toString();
+	public TokenInfoDto kakaoOAuthLogin(String idToken) {
+		HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(idToken);
+		String email = kakaoUserInfo.get("email").toString();
+		Provider provider = Provider.KAKAO;
 
-		Optional<Account> account = accountRepository.findByNickname(userNickname);
-		if (account.isEmpty()) {
-			Account newAccount = Account.builder()
-				.provider(Provider.KAKAO)
-				.nickname(kakaoUserInfo.get("nickname").toString())
-				.build();
-			accountRepository.save(newAccount);
+		if (accountRepository.notExistsAccountByEmailAndProvider(email, provider)) {
+			saveAccount(kakaoUserInfo, email);
 			return null;
 		}
+		return jwtTokenProvider.generateToken(getAuthentication(email, String.valueOf(provider)));
+	}
 
-		return jwtTokenProvider.generateToken(getAuthentication(userNickname));
+	private void saveAccount(HashMap<String, Object> kakaoUserInfo, String email) {
+		String nickname = kakaoUserInfo.get("nickname").toString();
+		String picture = kakaoUserInfo.get("picture").toString();
+		Account newAccount = Account.builder()
+			.provider(Provider.KAKAO)
+			.email(email)
+			.nickname(nickname)
+			.profile_image(picture)
+			.build();
+		accountRepository.save(newAccount);
 	}
 
 	public TokenInfoDto reGenerateAccessToken(RefreshTokenDto refreshTokenDto) {
 		String refreshToken = refreshTokenDto.getRefreshToken();
-		if (!jwtTokenProvider.validateToken(refreshToken)) {
+		if (!jwtTokenProvider.validateToken(refreshToken.substring(7).trim())) {
 			throw new ApiException(ErrorCode.INVALID_TOKEN);
 		}
 
-		String userNickname = jwtTokenProvider.extractUsernameFromJwt(refreshToken);
-		return jwtTokenProvider.generateToken(getAuthentication(userNickname));
+		TokenAccountInfoDto tokenAccountInfoDto = jwtTokenProvider.extractTokenAccountInfoFromJwt(refreshToken);
+		String email = tokenAccountInfoDto.getEmail();
+		String provider = tokenAccountInfoDto.getProvider();
+		return jwtTokenProvider.generateToken(getAuthentication(email, provider));
 	}
 
-	private Authentication getAuthentication(String userNickname) {
+	private Authentication getAuthentication(String email, String provider) {
 		Collection<GrantedAuthority> authorities = new ArrayList<>();
 		authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
 
-		Authentication authentication = new UsernamePasswordAuthenticationToken(userNickname, null, authorities);
+		Authentication authentication
+			= new UsernamePasswordAuthenticationToken(email + "," + provider, null, authorities);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 		return authentication;
 	}


### PR DESCRIPTION
##관련 이슈
https://onehunnit.atlassian.net/browse/OH-120

##작업 내용
- 유저 식별 수단 변경
기존: 유저를 nickname을 통해 식별
변경: email + provider를 통해 유저를 식별

- Jwt 토큰 로직 리팩토링
중복 코드 제거
토큰 정보에 email과 provider가 포함되게 수정

## 참고사항
