### PR TITLE
feat(OH-129): 안전 구역 관리 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     //spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -54,6 +55,12 @@ dependencies {
     //lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    //JTS
+    implementation 'org.locationtech.jts:jts-core:1.20.0'
+
+    // Hibernate Spatial
+    implementation 'org.hibernate:hibernate-spatial:6.0.0.Final'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
 
 			.authorizeHttpRequests(request -> request
 				.requestMatchers("/oauth/refresh-token").permitAll()
+				.requestMatchers("/district").permitAll()
+				.requestMatchers("/test/**").permitAll()
 				.requestMatchers("/oauth/kakao").permitAll()
 				.requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 				.requestMatchers("/accounts/sign-up").permitAll()

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/WebConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/WebConfig.java
@@ -1,0 +1,24 @@
+package kr.co.onehunnit.onhunnit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Configuration
+public class WebConfig {
+
+	@Bean
+	public DefaultUriBuilderFactory defaultUriBuilderFactory() {
+		DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory();
+		uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+		return uriBuilderFactory;
+	}
+
+	@Bean
+	public WebClient webClient() {
+		return WebClient.builder()
+			.uriBuilderFactory(defaultUriBuilderFactory())
+			.build();
+	}
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
 	NOT_EXIST_ACCOUNT(400, "계정 정보가 존재하지 않습니다.", 801),
 	NOT_EXIST_EMAIL(400, "이메일 정보가 존재하지 않습니다.", 802),
 
+	NOT_EXIST_DISTRICT(400, "행정 구역 정보가 존재하지 않습니다.", 901),
+
 	INVALID_TOKEN(401, "유효하지 않은 토큰입니다.", 1001),
 	UNKNOWN_ERROR(401, "토큰이 존재하지 않습니다.", 1002),
 	WRONG_TYPE_TOKEN(401, "변조된 토큰입니다.", 1003),

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/DistrictController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/DistrictController.java
@@ -1,0 +1,57 @@
+package kr.co.onehunnit.onhunnit.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.onehunnit.onhunnit.config.response.ResponseDto;
+import kr.co.onehunnit.onhunnit.config.response.ResponseUtil;
+import kr.co.onehunnit.onhunnit.dto.district.DistrictCoordinateResponseDto;
+import kr.co.onehunnit.onhunnit.dto.district.DistrictResponseDto;
+import kr.co.onehunnit.onhunnit.service.DistrictService;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "행정구역")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/district")
+public class DistrictController {
+
+	private final DistrictService districtService;
+
+	@Operation(summary = "행정구역 데이터 저장", description = "로컬에서 데이터 저장 용도, 배포 서버 사용X")
+	@GetMapping("/save-data")
+	public void processGeoJson() {
+		try {
+			districtService.saveDistrictsFromGeoJson(
+				"C:/Users/KoKyungNam/Desktop/fillbom/HangJeongDong_ver20241001.geojson");
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Operation(summary = "행정 구역 검색", description = "jwt 토큰 필요")
+	@GetMapping("/search")
+	public ResponseDto<List<DistrictResponseDto>> searchDistricts(@RequestParam String searchWord) {
+		return ResponseUtil.SUCCESS("검색에 성공하였습니다.", districtService.searchDistricts(searchWord));
+	}
+
+	@Operation(summary = "행정 구역 정보 조회", description = "jwt 토큰 필요, 좌표 제공")
+	@GetMapping("/coordinate")
+	public ResponseDto<DistrictCoordinateResponseDto> getDistrictCoordinate(@RequestParam String adm_cd) {
+		return ResponseUtil.SUCCESS("행정구역 조회에 성공하였습니다.", districtService.getDistrictCoordinate(adm_cd));
+	}
+
+	@Operation(summary = "행정구역 내에 포함 여부 확인", description = "jwt 토큰 필요")
+	@GetMapping("/check/location/safe-zone")
+	public String checkLocation(@RequestParam String adm_cd, @RequestParam double longitude, @RequestParam double latitude) {
+		boolean isInside = districtService.isPointInPolygon(adm_cd, longitude, latitude);
+		return isInside ? "현재위치가 행정구역 내에 포함됩니다." : "현재위치가 행정구역 내에 포함되지 않습니다.";
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/SafeZoneController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/SafeZoneController.java
@@ -1,0 +1,51 @@
+package kr.co.onehunnit.onhunnit.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.onehunnit.onhunnit.config.response.ResponseDto;
+import kr.co.onehunnit.onhunnit.config.response.ResponseUtil;
+import kr.co.onehunnit.onhunnit.dto.district.DistrictResponseDto;
+import kr.co.onehunnit.onhunnit.service.SafeZoneService;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "안전구역")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/safe-zone")
+public class SafeZoneController {
+
+	private final SafeZoneService safeZoneService;
+
+	@Operation(summary = "안전구역 설정")
+	@PostMapping("/patients/{patientId}")
+	public ResponseDto<Long> registerSafeZone(HttpServletRequest request, @PathVariable Long patientId,
+		@RequestParam(name = "adm_cd") String adm_cd) {
+		return ResponseUtil.SUCCESS("안전구역 설정에 성공하였습니다.",
+			safeZoneService.registerSafeZone(request.getHeader("Authorization"), patientId, adm_cd));
+	}
+
+	@Operation(summary = "안전구역 목록 조회")
+	@GetMapping("/patients/{patientId}")
+	public ResponseDto<List<DistrictResponseDto>> findAllSafeZone(@PathVariable Long patientId) {
+		return ResponseUtil.SUCCESS("안전구역 조회에 성공하였습니다.", safeZoneService.findAllSafeZone(patientId));
+	}
+
+	@Operation(summary = "안전구역 삭제")
+	@DeleteMapping("/{safeZoneId}")
+	public ResponseDto<Long> deleteSafeZone(@PathVariable Long safeZoneId) {
+		safeZoneService.deleteSafeZone(safeZoneId);
+		return ResponseUtil.SUCCESS("안전구역 삭제에 성공하였습니다.", safeZoneId);
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Caregiver.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Caregiver.java
@@ -38,6 +38,7 @@ public class Caregiver extends BaseTimeEntity implements Role {
 	@JoinColumn(name = "account_id")
 	private Account account;
 
+	@Builder.Default
 	@OneToMany(mappedBy = "caregiver")
 	private List<PatientCaregiver> patientCaregiverList = new ArrayList<>();
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/district/District.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/district/District.java
@@ -1,0 +1,43 @@
+package kr.co.onehunnit.onhunnit.domain.district;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.locationtech.jts.geom.MultiPolygon;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import kr.co.onehunnit.onhunnit.domain.safezone.SafeZone;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "districts")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class District {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String admNm;
+	private String admCd;
+
+	@Column(columnDefinition = "geometry(MULTIPOLYGON,4326)")
+	private MultiPolygon geom;
+
+	@Builder.Default
+	@OneToMany(mappedBy = "district")
+	private List<SafeZone> safeZoneList = new ArrayList<>();
+
+}
+

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/Feature.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/Feature.java
@@ -1,0 +1,15 @@
+package kr.co.onehunnit.onhunnit.domain.district.dbmapping;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Feature {
+	private String type;
+	private Properties properties;
+	private Geometry geometry;
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/FeatureCollection.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/FeatureCollection.java
@@ -1,0 +1,14 @@
+package kr.co.onehunnit.onhunnit.domain.district.dbmapping;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FeatureCollection {
+	private String type;
+	private List<Feature> features;
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/Geometry.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/Geometry.java
@@ -1,0 +1,12 @@
+package kr.co.onehunnit.onhunnit.domain.district.dbmapping;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Geometry {
+	private String type;
+	private double[][][][] coordinates;
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/Properties.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/district/dbmapping/Properties.java
@@ -1,0 +1,14 @@
+package kr.co.onehunnit.onhunnit.domain.district.dbmapping;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Properties {
+	private String adm_nm;
+	private String adm_cd2;
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/patient/Patient.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/patient/Patient.java
@@ -16,6 +16,7 @@ import kr.co.onehunnit.onhunnit.domain.account.Account;
 import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
 import kr.co.onehunnit.onhunnit.domain.global.Role;
 import kr.co.onehunnit.onhunnit.domain.patient_Caregiver.PatientCaregiver;
+import kr.co.onehunnit.onhunnit.domain.safezone.SafeZone;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,12 +35,17 @@ public class Patient extends BaseTimeEntity implements Role {
 
 	private String diagnosis;
 
-	@OneToMany(mappedBy = "patient")
-	private List<PatientCaregiver> patientCaregiverList = new ArrayList<>();
-
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "account_id")
 	private Account account;
+
+	@Builder.Default
+	@OneToMany(mappedBy = "patient")
+	private List<PatientCaregiver> patientCaregiverList = new ArrayList<>();
+
+	@Builder.Default
+	@OneToMany(mappedBy = "patient")
+	private List<SafeZone> safeZoneList = new ArrayList<>();
 
 	public void setAccount(Account account) {
 		this.account = account;

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/safezone/SafeZone.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/safezone/SafeZone.java
@@ -1,0 +1,36 @@
+package kr.co.onehunnit.onhunnit.domain.safezone;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.onehunnit.onhunnit.domain.district.District;
+import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class SafeZone extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "patient_id")
+	private Patient patient;
+
+	@ManyToOne
+	@JoinColumn(name = "district_id")
+	private District district;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/district/DistrictCoordinateResponseDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/district/DistrictCoordinateResponseDto.java
@@ -1,0 +1,26 @@
+package kr.co.onehunnit.onhunnit.dto.district;
+
+import org.locationtech.jts.geom.MultiPolygon;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DistrictCoordinateResponseDto {
+
+	@Schema(description = "행정구역 명칭")
+	private String admNm;
+
+	@Schema(description = "행정구역 코드")
+	private String admCd;
+
+	@Schema(description = "행정구역 좌표")
+	private String coordinate;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/district/DistrictResponseDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/district/DistrictResponseDto.java
@@ -1,0 +1,21 @@
+package kr.co.onehunnit.onhunnit.dto.district;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DistrictResponseDto {
+
+	@Schema(description = "행정구역 명칭")
+	private String adm_nm;
+
+	@Schema(description = "행정구역 코드")
+	private String adm_cd;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/DistrictRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/DistrictRepository.java
@@ -1,0 +1,17 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.district.District;
+
+@Repository
+public interface DistrictRepository extends JpaRepository<District, Long> {
+
+	Optional<District> findByAdmCd(String admCd);
+
+	List<District> findAllByAdmNmContainingOrderById(String admNm);
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/SafeZoneRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/SafeZoneRepository.java
@@ -1,0 +1,16 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import kr.co.onehunnit.onhunnit.domain.safezone.SafeZone;
+
+@Repository
+public interface SafeZoneRepository extends JpaRepository<SafeZone, Long> {
+
+	List<SafeZone> findAllByPatientOrderByCreatedAtDesc(Patient patient);
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/DistrictService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/DistrictService.java
@@ -1,0 +1,157 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.WKTReader;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.domain.district.District;
+import kr.co.onehunnit.onhunnit.domain.district.dbmapping.Feature;
+import kr.co.onehunnit.onhunnit.domain.district.dbmapping.FeatureCollection;
+import kr.co.onehunnit.onhunnit.dto.district.DistrictCoordinateResponseDto;
+import kr.co.onehunnit.onhunnit.dto.district.DistrictResponseDto;
+import kr.co.onehunnit.onhunnit.repository.DistrictRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class DistrictService {
+
+	private final DistrictRepository districtsRepository;
+	private final AccountService accountService;
+	private final DistrictRepository districtRepository;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final GeometryFactory geometryFactory = new GeometryFactory();
+
+	public void saveDistrictsFromGeoJson(String filePath) throws Exception {
+		FeatureCollection featureCollection = objectMapper.readValue(new File(filePath), FeatureCollection.class);
+
+		for (Feature feature : featureCollection.getFeatures()) {
+			// 좌표 변환: GeoJSON의 MULTIPOLYGON을 WKT로 변환
+			String wkt = convertToWKT(feature.getGeometry().getCoordinates());
+
+			District districts = District.builder()
+				.admNm(feature.getProperties().getAdm_nm())
+				.admCd(feature.getProperties().getAdm_cd2())
+				.geom((MultiPolygon)new WKTReader(geometryFactory).read(wkt))
+				.build();
+
+			districtsRepository.save(districts);
+		}
+	}
+
+	private String convertToWKT(double[][][][] coordinates) {
+		StringBuilder wktBuilder = new StringBuilder("MULTIPOLYGON((");
+
+		for (double[][][] polygon : coordinates) {
+			wktBuilder.append("(");
+			for (double[][] boundary : polygon) {
+				if (boundary.length > 0) {
+					for (double[] point : boundary) {
+						wktBuilder.append(point[0]).append(" ").append(point[1]).append(", ");
+					}
+					wktBuilder.setLength(wktBuilder.length() - 2);
+					wktBuilder.append(", ");
+				}
+			}
+			wktBuilder.setLength(wktBuilder.length() - 2);
+			wktBuilder.append("), ");
+		}
+		wktBuilder.setLength(wktBuilder.length() - 2);
+		wktBuilder.append("))");
+
+		// System.out.println("Generated WKT: " + wktBuilder.toString());
+		return wktBuilder.toString();
+	}
+
+	public List<DistrictResponseDto> searchDistricts(String searchWord) {
+		List<District> searchedDistrictList = districtRepository.findAllByAdmNmContainingOrderById(searchWord);
+		return convertoToDistrictResponseDtoList(searchedDistrictList);
+	}
+
+	private static List<DistrictResponseDto> convertoToDistrictResponseDtoList(List<District> searchedDistrictList) {
+		List<DistrictResponseDto> districtResponseDtoList = new ArrayList<>();
+		for (District district : searchedDistrictList) {
+			DistrictResponseDto districtResponseDto = DistrictResponseDto.builder()
+				.adm_cd(district.getAdmCd())
+				.adm_nm(district.getAdmNm())
+				.build();
+			districtResponseDtoList.add(districtResponseDto);
+		}
+		return districtResponseDtoList;
+	}
+
+	public String convertMultiPolygonToGeoJson(MultiPolygon multiPolygon) {
+		ObjectNode geoJson = objectMapper.createObjectNode();
+		geoJson.put("type", "MultiPolygon");
+
+		ArrayNode coordinates = objectMapper.createArrayNode();
+
+		for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
+			Polygon polygon = (Polygon)multiPolygon.getGeometryN(i);
+			ArrayNode polygonCoordinates = objectMapper.createArrayNode();
+			ArrayNode ringCoordinates = objectMapper.createArrayNode();
+
+			for (Coordinate coordinate : polygon.getCoordinates()) {
+				ArrayNode coord = objectMapper.createArrayNode();
+				coord.add(coordinate.x); // 경도
+				coord.add(coordinate.y); // 위도
+				ringCoordinates.add(coord);
+			}
+
+			// 첫 번째 점으로 돌아가는 것을 보장하기 위해 마지막 점 추가
+			if (ringCoordinates.size() > 0) {
+				ArrayNode firstCoord = objectMapper.createArrayNode();
+				firstCoord.add(ringCoordinates.get(0).get(0));
+				firstCoord.add(ringCoordinates.get(0).get(1));
+				ringCoordinates.add(firstCoord);
+			}
+
+			polygonCoordinates.add(ringCoordinates);
+			coordinates.add(polygonCoordinates);
+		}
+
+		geoJson.set("coordinates", coordinates);
+
+		return geoJson.toString();
+	}
+
+	public DistrictCoordinateResponseDto getDistrictCoordinate(String admCd) {
+		District district = districtRepository.findByAdmCd(admCd).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_DISTRICT));
+
+		return DistrictCoordinateResponseDto.builder()
+			.admNm(district.getAdmNm())
+			.admCd(district.getAdmCd())
+			.coordinate(convertMultiPolygonToGeoJson(district.getGeom()))
+			.build();
+	}
+
+	public boolean isPointInPolygon(String admCd, double longitude, double latitude) {
+		District district = districtsRepository.findByAdmCd(admCd).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_DISTRICT));
+
+		if (district != null && district.getGeom() != null) {
+			MultiPolygon multiPolygon = district.getGeom();
+			Point point = geometryFactory.createPoint(new org.locationtech.jts.geom.Coordinate(longitude, latitude));
+			return multiPolygon.contains(point);
+		}
+
+		throw new ApiException(ErrorCode.NOT_EXIST_DISTRICT);
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/SafeZoneService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/SafeZoneService.java
@@ -1,0 +1,67 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.domain.district.District;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import kr.co.onehunnit.onhunnit.domain.safezone.SafeZone;
+import kr.co.onehunnit.onhunnit.dto.district.DistrictResponseDto;
+import kr.co.onehunnit.onhunnit.repository.DistrictRepository;
+import kr.co.onehunnit.onhunnit.repository.PatientRepository;
+import kr.co.onehunnit.onhunnit.repository.SafeZoneRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SafeZoneService {
+
+	private final AccountService accountService;
+	private final PatientRepository patientRepository;
+	private final DistrictRepository districtRepository;
+	private final SafeZoneRepository safeZoneRepository;
+
+	public Long registerSafeZone(String accessToken, Long patientId, String adm_cd) {
+		accountService.getAccountByToken(accessToken);
+
+		Patient patient = patientRepository.findById(patientId).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+		District district = districtRepository.findByAdmCd(adm_cd).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_DISTRICT));
+
+		SafeZone safeZone = SafeZone.builder()
+			.patient(patient)
+			.district(district)
+			.build();
+		return safeZoneRepository.save(safeZone).getId();
+	}
+
+	public List<DistrictResponseDto> findAllSafeZone(Long patientId) {
+		Patient patient = patientRepository.findById(patientId).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+		List<SafeZone> safeZoneList = safeZoneRepository.findAllByPatientOrderByCreatedAtDesc(patient);
+		return convertToDistrictResponseDtoList(safeZoneList);
+	}
+
+	private static List<DistrictResponseDto> convertToDistrictResponseDtoList(List<SafeZone> safeZoneList) {
+		List<DistrictResponseDto> districtResponseDtoList = new ArrayList<>();
+		for (SafeZone safeZone : safeZoneList) {
+			DistrictResponseDto districtResponseDto = DistrictResponseDto.builder()
+				.adm_nm(safeZone.getDistrict().getAdmNm())
+				.adm_cd(safeZone.getDistrict().getAdmCd())
+				.build();
+			districtResponseDtoList.add(districtResponseDto);
+		}
+		return districtResponseDtoList;
+	}
+
+	public void deleteSafeZone(Long safeZoneId) {
+		safeZoneRepository.deleteById(safeZoneId);
+	}
+}


### PR DESCRIPTION
##관련 이슈
https://onehunnit.atlassian.net/browse/OH-129

##작업 내용
- 안전구역 생성, 조회, 삭제 API 개발
- 행정구역 검색 API 개발
- 행정구역 코드를 통한 정보 조회 API 개발 행정구역의 경계면은 geojson 형태로 제공
- 현재위치 행정구역 내에 포함 여부 확인 API 개발

## 참고사항
