### PR TITLE
feat(OH-139): 일기 관리 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
     // Hibernate Spatial
     implementation 'org.hibernate:hibernate-spatial:6.0.0.Final'
 
+    //AWS S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.300'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
 
 	NOT_EXIST_DISTRICT(400, "행정 구역 정보가 존재하지 않습니다.", 901),
 
+	NOT_EXITS_DIARY(400, "일기 정보가 존재하지 않습니다.", 1001),
+
 	INVALID_TOKEN(401, "유효하지 않은 토큰입니다.", 1001),
 	UNKNOWN_ERROR(401, "토큰이 존재하지 않습니다.", 1002),
 	WRONG_TYPE_TOKEN(401, "변조된 토큰입니다.", 1003),
@@ -32,6 +34,7 @@ public enum ErrorCode {
 	RESPONSE_CODE_ERROR(401, "인가 코드 요청에 따른 응답 코드가 200이 아닙니다.", 1010),
 	FAILED_TO_RETRIEVE_KAKAO_USER_INFO(401, "카카오로부터 유저 정보 발급에 실패했습니다.", 1011),
 	NO_TOKEN_ACCOUNT(401, "토큰에 해당하는 계정 정보가 없습니다.", 1012),
+	UNAUTHORIZED_ACCESS(401, "권한이 없는 환자의 정보를 조회할 수 없습니다.", 1013),
 	;
 
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/DiaryController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/DiaryController.java
@@ -1,0 +1,77 @@
+package kr.co.onehunnit.onhunnit.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.onehunnit.onhunnit.config.response.ResponseDto;
+import kr.co.onehunnit.onhunnit.config.response.ResponseUtil;
+import kr.co.onehunnit.onhunnit.dto.diary.DiaryRequestDto;
+import kr.co.onehunnit.onhunnit.dto.diary.DiaryResponseDto;
+import kr.co.onehunnit.onhunnit.service.DiaryServiceForCaregiver;
+import kr.co.onehunnit.onhunnit.service.DiaryServiceForPatient;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "일기")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/diaries")
+public class DiaryController {
+
+	private final DiaryServiceForPatient diaryServiceForPatient;
+	private final DiaryServiceForCaregiver diaryServiceForCaregiver;
+
+	@Operation(summary = "일기 저장")
+	@PostMapping("")
+	public ResponseDto<Long> saveDiary(HttpServletRequest request, @RequestBody DiaryRequestDto diaryRequestDto) {
+		return ResponseUtil.SUCCESS("일기 저장에 성공하였습니다.",
+			diaryServiceForPatient.saveDiary(request.getHeader("Authorization"), diaryRequestDto));
+	}
+
+	@Operation(summary = "환자가 전체 일기 목록 조회")
+	@GetMapping("/all")
+	public ResponseDto<List<DiaryResponseDto.Brief>> findAllDiary(HttpServletRequest request) {
+		return ResponseUtil.SUCCESS("전체 목록 조회에 성공하였습니다.",
+			diaryServiceForPatient.findAllDiary(request.getHeader("Authorization")));
+	}
+
+	@Operation(summary = "환자가 일기 조회")
+	@GetMapping("/{diaryId}")
+	public ResponseDto<DiaryResponseDto.Detail> findDiaryById(HttpServletRequest request, @PathVariable Long diaryId) {
+		return ResponseUtil.SUCCESS("일기 조회에 성공하였습니다.",
+			diaryServiceForPatient.findDiaryById(request.getHeader("Authorization"), diaryId));
+	}
+
+	@Operation(summary = "환자가 일기 삭제")
+	@DeleteMapping("/{diaryId}")
+	public String deleteDiaryById(HttpServletRequest request, @PathVariable Long diaryId) {
+		diaryServiceForPatient.deleteDiaryById(request.getHeader("Authorization"), diaryId);
+		return "일기 삭제에 성공하였습니다.";
+	}
+
+	@Operation(summary = "보호자가 환자의 일기 목록 조회", description = "환자가 공유 허용한 일기만 조회")
+	@GetMapping("/patients/{patientId}/caregivers")
+	public ResponseDto<List<DiaryResponseDto.Brief>> findPatientDiariesForCaregivers(HttpServletRequest request,
+		@PathVariable Long patientId) {
+		return ResponseUtil.SUCCESS("환자의 일기 목록 조회에 성공하였습니다.",
+			diaryServiceForCaregiver.findPatientDiariesForCaregiver(request.getHeader("Authorization"), patientId));
+	}
+
+	@Operation(summary = "보호자가 환자의 일기 조회", description = "환자가 공유 허용한 일기만 조회")
+	@GetMapping("{diaryId}/patients/{patientId}/caregivers")
+	public ResponseDto<DiaryResponseDto.Detail> findPatientDiaryForCaregivers(HttpServletRequest request,
+		@PathVariable Long patientId, @PathVariable Long diaryId) {
+		return ResponseUtil.SUCCESS("환자의 일기 조회에 성공하였습니다.",
+			diaryServiceForCaregiver.findPatientDiaryForCaregiver(request.getHeader("Authorization"), patientId, diaryId));
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Diary.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Diary.java
@@ -1,0 +1,42 @@
+package kr.co.onehunnit.onhunnit.domain.diary;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.onehunnit.onhunnit.domain.global.BaseTimeEntity;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Diary extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	private Emotion emotionState;
+
+	private boolean shared;
+
+	@ManyToOne
+	@JoinColumn(name = "patient_id")
+	private Patient patient;
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Emotion.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Emotion.java
@@ -1,0 +1,16 @@
+package kr.co.onehunnit.onhunnit.domain.diary;
+
+public enum Emotion {
+
+	HAPPINESS("행복"),
+	SADNESS("슬픔"),
+	ANGER("분노"),
+	ANXIETY("걱정"),
+	CALMNESS("평온");
+
+	private final String description;
+
+	private Emotion(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/DiaryRequestDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/DiaryRequestDto.java
@@ -1,0 +1,31 @@
+package kr.co.onehunnit.onhunnit.dto.diary;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.onehunnit.onhunnit.domain.diary.Diary;
+import kr.co.onehunnit.onhunnit.domain.diary.Emotion;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DiaryRequestDto {
+	@Schema(description = "제목")
+	private String title;
+	@Schema(description = "내용")
+	private String content;
+	@Schema(description = "감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS")
+	private String emotionState;
+	@Schema(description = "공유여부")
+	private boolean shared;
+
+	public Diary toEntity(DiaryRequestDto requestDto, Patient patient) {
+		return Diary.builder()
+			.title(requestDto.getTitle())
+			.content(requestDto.getContent())
+			.emotionState(Emotion.valueOf(requestDto.getEmotionState()))
+			.shared(requestDto.isShared())
+			.patient(patient)
+			.build();
+	}
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/DiaryResponseDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/DiaryResponseDto.java
@@ -1,0 +1,38 @@
+package kr.co.onehunnit.onhunnit.dto.diary;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.onehunnit.onhunnit.domain.diary.Emotion;
+import lombok.Builder;
+import lombok.Getter;
+
+public class DiaryResponseDto {
+
+	@Getter
+	@Builder
+	public static class Brief{
+		@Schema(description = "일기 인덱스")
+		private Long id;
+		@Schema(description = "제목")
+		private String title;
+		@Schema(description = "감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS")
+		private Emotion emotionState;
+		@Schema(description = "생성일자")
+		private LocalDateTime createdAt;
+	}
+
+	@Getter
+	@Builder
+	public static class Detail {
+		@Schema(description = "제목")
+		private String title;
+		@Schema(description = "내용")
+		private String content;
+		@Schema(description = "감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS")
+		private Emotion emotionState;
+		@Schema(description = "생성일자")
+		private LocalDateTime createdAt;
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/repository/DiaryRepository.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/repository/DiaryRepository.java
@@ -1,0 +1,18 @@
+package kr.co.onehunnit.onhunnit.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.co.onehunnit.onhunnit.domain.diary.Diary;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+	List<Diary> findAllByPatientOrderByCreatedAtDesc(Patient patient);
+
+	List<Diary> findAllByPatientAndSharedTrueOrderByCreatedAtDesc(Patient patient);
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/DiaryServiceForCaregiver.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/DiaryServiceForCaregiver.java
@@ -1,0 +1,87 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+import kr.co.onehunnit.onhunnit.domain.account.Caregiver;
+import kr.co.onehunnit.onhunnit.domain.diary.Diary;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import kr.co.onehunnit.onhunnit.dto.diary.DiaryResponseDto;
+import kr.co.onehunnit.onhunnit.repository.CaregiverRepository;
+import kr.co.onehunnit.onhunnit.repository.DiaryRepository;
+import kr.co.onehunnit.onhunnit.repository.PatientRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class DiaryServiceForCaregiver {
+
+	private final DiaryRepository diaryRepository;
+	private final PatientRepository patientRepository;
+	private final CaregiverRepository caregiverRepository;
+
+	private final AccountService accountService;
+
+	public List<DiaryResponseDto.Brief> findPatientDiariesForCaregiver(String accessToken, Long patientId) {
+		Caregiver caregiver = getCaregiverByAccessToken(accessToken);
+		Patient patient = patientRepository.findById(patientId).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+
+		if (isNotCaregiverOfPatient(caregiver, patient)) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED_ACCESS);
+		}
+
+		return diaryRepository.findAllByPatientAndSharedTrueOrderByCreatedAtDesc(patient).stream()
+			.map(this::convertToBriefDto)
+			.collect(Collectors.toList());
+	}
+
+	public DiaryResponseDto.Detail findPatientDiaryForCaregiver(String accessToken, Long patientId,
+		Long diaryId) {
+		Caregiver caregiver = getCaregiverByAccessToken(accessToken);
+		Patient patient = patientRepository.findById(patientId).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+
+		if (isNotCaregiverOfPatient(caregiver, patient)) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED_ACCESS);
+		}
+
+		Diary diary = diaryRepository.findById(diaryId).filter(d -> d.getPatient().equals(patient))
+			.orElseThrow(() -> new ApiException(ErrorCode.NOT_EXITS_DIARY));
+
+		return DiaryResponseDto.Detail.builder()
+			.title(diary.getTitle())
+			.content(diary.getContent())
+			.emotionState(diary.getEmotionState())
+			.createdAt(diary.getCreatedAt())
+			.build();
+	}
+
+	private Caregiver getCaregiverByAccessToken(String accessToken) {
+		Account account = accountService.getAccountByToken(accessToken);
+		return caregiverRepository.findByAccount_Id(account.getId()).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+	}
+
+	private DiaryResponseDto.Brief convertToBriefDto(Diary diary) {
+		return DiaryResponseDto.Brief.builder()
+			.id(diary.getId())
+			.title(diary.getTitle())
+			.emotionState(diary.getEmotionState())
+			.createdAt(diary.getCreatedAt())
+			.build();
+	}
+
+	private boolean isNotCaregiverOfPatient(Caregiver caregiver, Patient patient) {
+		return caregiver.getPatientCaregiverList().stream()
+			.noneMatch(pc -> pc.getPatient().equals(patient));
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/DiaryServiceForPatient.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/DiaryServiceForPatient.java
@@ -1,0 +1,82 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import kr.co.onehunnit.onhunnit.domain.account.Account;
+import kr.co.onehunnit.onhunnit.domain.diary.Diary;
+import kr.co.onehunnit.onhunnit.domain.patient.Patient;
+import kr.co.onehunnit.onhunnit.dto.diary.DiaryRequestDto;
+import kr.co.onehunnit.onhunnit.dto.diary.DiaryResponseDto;
+import kr.co.onehunnit.onhunnit.repository.DiaryRepository;
+import kr.co.onehunnit.onhunnit.repository.PatientRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DiaryServiceForPatient {
+
+	private final DiaryRepository diaryRepository;
+	private final PatientRepository patientRepository;
+
+	private final AccountService accountService;
+
+	public Long saveDiary(String accessToken, DiaryRequestDto diaryRequestDto) {
+		Patient patient = getPatientByAccessToken(accessToken);
+		Diary diary = diaryRequestDto.toEntity(diaryRequestDto, patient);
+		return diaryRepository.save(diary).getId();
+	}
+
+	@Transactional(readOnly = true)
+	public List<DiaryResponseDto.Brief> findAllDiary(String accessToken) {
+		Patient patient = getPatientByAccessToken(accessToken);
+		return diaryRepository.findAllByPatientOrderByCreatedAtDesc(patient).stream()
+			.map(this::convertToBriefDto)
+			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public DiaryResponseDto.Detail findDiaryById(String accessToken, Long diaryId) {
+		Patient patient = getPatientByAccessToken(accessToken);
+		Diary diary = diaryRepository.findById(diaryId).filter(d -> d.getPatient().equals(patient))
+			.orElseThrow(() -> new ApiException(ErrorCode.NOT_EXITS_DIARY));
+
+		return DiaryResponseDto.Detail.builder()
+			.title(diary.getTitle())
+			.content(diary.getContent())
+			.emotionState(diary.getEmotionState())
+			.createdAt(diary.getCreatedAt())
+			.build();
+	}
+
+	public void deleteDiaryById(String accessToken, Long diaryId) {
+		Patient patient = getPatientByAccessToken(accessToken);
+		Diary diary = diaryRepository.findById(diaryId)
+			.filter(d -> d.getPatient().equals(patient)) // 환자와 일기 비교
+			.orElseThrow(() -> new ApiException(ErrorCode.NOT_EXITS_DIARY));
+
+		diaryRepository.delete(diary);
+	}
+
+	private Patient getPatientByAccessToken(String accessToken) {
+		Account account = accountService.getAccountByToken(accessToken);
+		return patientRepository.findByAccount_Id(account.getId()).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
+	}
+
+	private DiaryResponseDto.Brief convertToBriefDto(Diary diary) {
+		return DiaryResponseDto.Brief.builder()
+			.id(diary.getId())
+			.title(diary.getTitle())
+			.emotionState(diary.getEmotionState())
+			.createdAt(diary.getCreatedAt())
+			.build();
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OH-139

## 작업 내용
- 일기 생성, 조회, 삭제 API 개발
환자
- 일기 생성, 목록 조회, 상세 조회, 삭제 가능
- 일기 생성 시, 보호자에게 공유 여부 설정 가능

보호자
- 환자의 일기 목록 조회, 상세 조회 가능
- 환자가 공유 여부를 false로 설정하면 조회 불가

## 참고사항
일기 사진은 Key 발급받는대로 바로 작성하겠습니다.