### PR TITLE
fix: SecurityConfig 파일 수정

### DIFF
--- a/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package kr.co.onehunnit.onhunnit.config;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.springframework.context.annotation.Bean;
@@ -39,10 +40,10 @@ public class SecurityConfig {
 				@Override
 				public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
 					CorsConfiguration config = new CorsConfiguration();
-					config.setAllowedOrigins(Collections.singletonList("*")); //테스트를 위해 일단 전체 허용
-					config.setAllowedMethods(Collections.singletonList("*"));
+					config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080", "https://api.fillbom.com"));
+					config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 					config.setAllowCredentials(true);
-					config.setAllowedHeaders(Collections.singletonList("*"));
+					config.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
 					config.setMaxAge(3600L);
 					return config;
 				}


### PR DESCRIPTION
## 작업 내용
- Origins, Methods, Headers 요소 추가

## 참고사항
java.lang.IllegalArgumentException: When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Orig
해당에러가 발생해서 변경했습니다.