### PR TITLE
feat(OH-219): CI 테스트 자동화

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,7 +30,17 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: clean build -x test
+          arguments: clean build
+
+#      - name: Run tests with Gradle
+#        id: test
+#        run: ./gradlew test
+
+      - name: 테스트 결과를 PR에 코멘트로 등록
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
 
       - name: Docker build & push to Docker repo
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -88,3 +88,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+test {
+    exclude '**/OAuthServiceTest.class'
+}


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OH-219

## 작업 내용
- cicd.yml에 테스트 실행 코드 추가

## 참고사항
- OAuthServiceTest의 경우 테스트를 위해서 idToken이 필요한데, 이 값은 만료 기한이 있고, 외부에 노출되면 안될 것 같아 test 실행에서 제외하였습니다.