### PR TITLE
feat(OH-218): 애플 소셜로그인 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'com.auth0:java-jwt:4.4.0'
+
+    // jwks
+    implementation 'com.auth0:jwks-rsa:0.22.0'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
 				// .requestMatchers("/**").permitAll()
 				.requestMatchers("/oauth/refresh-token").permitAll()
 				.requestMatchers("/district").permitAll()
-				.requestMatchers("/oauth/kakao").permitAll()
+				.requestMatchers("/oauth/**").permitAll()
 				.requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 				.requestMatchers("/accounts/sign-up").permitAll()
 				.requestMatchers("/accounts/sign-in").permitAll()

--- a/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/config/exception/ErrorCode.java
@@ -38,8 +38,12 @@ public enum ErrorCode {
 	FAILED_TO_RETRIEVE_KAKAO_ACCESS_TOKEN(401, "카카오로부터 AccessToken 발급에 실패했습니다.", 1009),
 	RESPONSE_CODE_ERROR(401, "인가 코드 요청에 따른 응답 코드가 200이 아닙니다.", 1010),
 	FAILED_TO_RETRIEVE_KAKAO_USER_INFO(401, "카카오로부터 유저 정보 발급에 실패했습니다.", 1011),
-	NO_TOKEN_ACCOUNT(401, "토큰에 해당하는 계정 정보가 없습니다.", 1012),
-	UNAUTHORIZED_ACCESS(401, "권한이 없는 환자의 정보를 조회할 수 없습니다.", 1013),
+	FAILED_TO_RETRIEVE_APPLE_USER_INFO(401, "애플로부터 유저 정보 발급에 실패했습니다.", 1012),
+	NO_TOKEN_ACCOUNT(401, "토큰에 해당하는 계정 정보가 없습니다.", 1013),
+	UNAUTHORIZED_ACCESS(401, "권한이 없는 환자의 정보를 조회할 수 없습니다.", 1014),
+	NOT_VALIDATE_EMAIL(401, "인증받지 못한 이메일입니다.", 1015),
+	FAIL_TO_DECODE(401, "헤더 디코딩에 실패했습니다.", 1016),
+	FAIL_TO_GET_PUBLIC_KEY(401, "공개 키를 가져오는 데 실패했습니다.", 1017),
 	;
 
 

--- a/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/controller/OAuthController.java
@@ -17,7 +17,7 @@ import kr.co.onehunnit.onhunnit.service.OAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Tag(name = "회원가입, 로그인, 토큰")
+@Tag(name = "소셜 로그인, 토큰")
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -30,6 +30,12 @@ public class OAuthController {
 	@PostMapping("/kakao")
 	public ResponseDto<TokenInfoDto> kakaoLogin(@Valid @RequestBody IdTokenDto idTokenDto) {
 		return ResponseUtil.SUCCESS("카카오 로그인에 성공하였습니다.", oAuthService.kakaoOAuthLogin(idTokenDto.getIdToken()));
+	}
+
+	@Operation(summary = "애플 소셜로그인")
+	@PostMapping("/apple")
+	public ResponseDto<TokenInfoDto> appleLogin(@Valid @RequestBody IdTokenDto idTokenDto) {
+		return ResponseUtil.SUCCESS("애플 로그인에 성공하였습니다.", oAuthService.appleOAuthLogin(idTokenDto.getIdToken()));
 	}
 
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰 앞에 토큰 타입 'Bearer ' 필요")

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Account.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/account/Account.java
@@ -33,7 +33,7 @@ public class Account extends BaseTimeEntity {
 	@Enumerated(value = EnumType.STRING)
 	private Provider provider;
 
-	private String profile_image;
+	private String profileImageUrl;
 
 	private String name;
 
@@ -55,7 +55,7 @@ public class Account extends BaseTimeEntity {
 		this.phone = requestDto.getPhone();
 		this.gender = Gender.valueOf(requestDto.getGender());
 		this.birthday = requestDto.getBirthday();
-		this.profile_image = requestDto.getProfile_image();
+		this.profileImageUrl = requestDto.getProfileImageUrl();
 
 		return this;
 	}
@@ -63,7 +63,7 @@ public class Account extends BaseTimeEntity {
 	public void update(AccountRequestDto.Update updateDto) {
 		this.name = updateDto.getName();
 		this.birthday = updateDto.getBirthday();
-		this.profile_image = updateDto.getProfile_image();
+		this.profileImageUrl = updateDto.getProfile_image();
 		this.phone = updateDto.getPhone();
 		this.gender = updateDto.getGender();
 	}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/account/AccountRequestDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/account/AccountRequestDto.java
@@ -24,7 +24,7 @@ public class AccountRequestDto {
 		private String birthday;
 
 		@Schema(description = "프로필이미지 url")
-		private String profile_image;
+		private String profileImageUrl;
 
 		@Schema(description = "역할(PATIENT,CAREGIVER)")
 		private String role;

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/account/TokenAccountInfoDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/account/TokenAccountInfoDto.java
@@ -46,7 +46,7 @@ public class TokenAccountInfoDto {
 		this.id = account.getId();
 		this.email = account.getEmail();
 		this.provider = account.getProvider();
-		this.profile_image = account.getProfile_image();
+		this.profile_image = account.getProfileImageUrl();
 		this.name = account.getName();
 		this.age = age;
 		this.phone = account.getPhone();

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/AccountService.java
@@ -44,7 +44,7 @@ public class AccountService {
 			Caregiver caregiver = Caregiver.builder().account(account).build();
 			caregiverRepository.save(caregiver);
 		}
-		return requestDto.getProfile_image();
+		return requestDto.getProfileImageUrl();
 	}
 
 	public AccountResponseDto.Info updateUserInfo(String accessToken, AccountRequestDto.Update updateDto) {
@@ -54,7 +54,7 @@ public class AccountService {
 			.id(account.getId())
 			.email(account.getEmail())
 			.phone(account.getPhone())
-			.profile_image(account.getProfile_image())
+			.profile_image(account.getProfileImageUrl())
 			.name(account.getName())
 			.birthday(account.getBirthday())
 			.gender(account.getGender())

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/AppleSocialService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/AppleSocialService.java
@@ -1,0 +1,70 @@
+package kr.co.onehunnit.onhunnit.service;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.UrlJwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class AppleSocialService {
+
+	private static final String APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+	private static final String ISSUER = "https://appleid.apple.com";
+
+	public DecodedJWT decodeAppleIdToken(String idToken) {
+		String[] tokenParts = idToken.split("\\.");
+		Map<String, Object> header = decodeHeader(tokenParts[0]);
+		RSAPublicKey publicKey = getPublicKey(header);
+		JWTVerifier verifier = createJWTVerifier(publicKey);
+		return verifier.verify(idToken);
+	}
+
+	private Map<String, Object> decodeHeader(String headerPart) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			return mapper.readValue(
+				new String(Base64.getUrlDecoder().decode(headerPart)),
+				new TypeReference<Map<String, Object>>() {
+				}
+			);
+		} catch (Exception e) {
+			throw new ApiException(ErrorCode.FAIL_TO_DECODE);
+		}
+	}
+
+	private RSAPublicKey getPublicKey(Map<String, Object> header) {
+		String keyId = header.get("kid").toString();
+		try {
+			JwkProvider provider = new UrlJwkProvider(new URL(APPLE_KEYS_URL));
+			return (RSAPublicKey)provider.get(keyId).getPublicKey();
+		} catch (Exception e) {
+			throw new ApiException(ErrorCode.FAIL_TO_GET_PUBLIC_KEY);
+		}
+	}
+
+	private JWTVerifier createJWTVerifier(RSAPublicKey publicKey) {
+		Algorithm algorithm = Algorithm.RSA256(publicKey, null);
+		return JWT.require(algorithm)
+			.withIssuer(ISSUER)
+			.build();
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/CaregiverService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/CaregiverService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.co.onehunnit.onhunnit.config.exception.ApiException;
 import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
 import kr.co.onehunnit.onhunnit.domain.account.Account;
-import kr.co.onehunnit.onhunnit.domain.account.AccountDetails;
 import kr.co.onehunnit.onhunnit.domain.caregiver.Caregiver;
 import kr.co.onehunnit.onhunnit.domain.patient.Patient;
 import kr.co.onehunnit.onhunnit.domain.patient_Caregiver.PatientCaregiver;
@@ -59,7 +58,7 @@ public class CaregiverService {
 			.orElseThrow(() -> new ApiException(ErrorCode.NOT_EXIST_PATIENT));
 
 		return PatientResponseDto.BriefDetail.builder()
-			.profileImageUrl(patient.getAccount().getProfile_image())
+			.profileImageUrl(patient.getAccount().getProfileImageUrl())
 			.name(patient.getAccount().getName())
 			.relationship(patientCaregiver.getRelationship())
 			.isAccepted(patientCaregiver.is_accepted())

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/OAuthService.java
@@ -3,6 +3,7 @@ package kr.co.onehunnit.onhunnit.service;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -12,7 +13,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.auth0.jwt.interfaces.Claim;
+
 import io.jsonwebtoken.JwtException;
+import kr.co.onehunnit.onhunnit.config.exception.ApiException;
+import kr.co.onehunnit.onhunnit.config.exception.ErrorCode;
 import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
 import kr.co.onehunnit.onhunnit.domain.account.Account;
 import kr.co.onehunnit.onhunnit.domain.account.Provider;
@@ -28,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class OAuthService {
 
 	private final KakaoSocialService kakaoSocialService;
+	private final AppleSocialService appleSocialService;
 	private final AccountRepository accountRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
@@ -36,22 +42,46 @@ public class OAuthService {
 		String email = kakaoUserInfo.get("email").toString();
 		Provider provider = Provider.KAKAO;
 
-		if (accountRepository.notExistsAccountByEmailAndProvider(email, provider)) {
-			saveAccount(kakaoUserInfo, email);
+		if (isNewAccount(email, provider)) {
+			saveAccount(email, provider);
 		}
 		return jwtTokenProvider.generateToken(getAuthentication(email, String.valueOf(provider)));
 	}
 
-	private void saveAccount(HashMap<String, Object> kakaoUserInfo, String email) {
-		String nickname = kakaoUserInfo.get("nickname").toString();
-		String picture = kakaoUserInfo.get("picture").toString();
-		Account newAccount = Account.builder()
-			.provider(Provider.KAKAO)
-			.email(email)
-			.name(nickname)
-			.profile_image(picture)
-			.build();
+	public TokenInfoDto appleOAuthLogin(String idToken) {
+		Map<String, Claim> appleUserInfo = appleSocialService.decodeAppleIdToken(idToken).getClaims();
+		String email = appleUserInfo.get("email").asString();
+		Provider provider = Provider.APPLE;
+
+		validateEmail(appleUserInfo);
+
+		if (isNewAccount(email, provider)) {
+			saveAccount(email, provider);
+		}
+		return jwtTokenProvider.generateToken(getAuthentication(email, String.valueOf(provider)));
+	}
+
+	private void validateEmail(Map<String, Claim> appleUserInfo) {
+		Boolean emailVerified = appleUserInfo.get("email_verified").asBoolean();
+		if (emailVerified == null || !emailVerified) {
+			throw new ApiException(ErrorCode.NOT_VALIDATE_EMAIL);
+		}
+	}
+
+	private boolean isNewAccount(String email, Provider provider) {
+		return accountRepository.notExistsAccountByEmailAndProvider(email, provider);
+	}
+
+	private void saveAccount(String email, Provider provider) {
+		Account newAccount = createAccount(email, provider);
 		accountRepository.save(newAccount);
+	}
+
+	private Account createAccount(String email, Provider provider) {
+		return Account.builder()
+			.provider(provider)
+			.email(email)
+			.build();
 	}
 
 	public TokenInfoDto reGenerateAccessToken(RefreshTokenDto refreshTokenDto) throws JwtException {

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/PatientService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/PatientService.java
@@ -1,6 +1,5 @@
 package kr.co.onehunnit.onhunnit.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -53,7 +52,7 @@ public class PatientService {
 			.map(accout -> PatientResponseDto.Phone.builder()
 				.name(accout.getName())
 				.phoneNumber(accout.getPhone())
-				.profileImageUrl(accout.getProfile_image())
+				.profileImageUrl(accout.getProfileImageUrl())
 				.build())
 			.collect(Collectors.toList());
 	}
@@ -71,7 +70,7 @@ public class PatientService {
 		PatientResponseDto.Location location = redisUtils.getLocationByPatientId(patientId);
 
 		return PatientResponseDto.Detail.builder()
-			.profileImageUrl(patient.getAccount().getProfile_image())
+			.profileImageUrl(patient.getAccount().getProfileImageUrl())
 			.name(patient.getRoleName())
 			.gender(patient.getAccount().getGender())
 			.birthday(patient.getAccount().getBirthday())

--- a/src/test/java/kr/co/onehunnit/onhunnit/service/OAuthServiceTest.java
+++ b/src/test/java/kr/co/onehunnit/onhunnit/service/OAuthServiceTest.java
@@ -11,10 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import kr.co.onehunnit.onhunnit.config.jwt.JwtTokenProvider;
 import kr.co.onehunnit.onhunnit.domain.account.Account;
-import kr.co.onehunnit.onhunnit.domain.account.Provider;
-import kr.co.onehunnit.onhunnit.dto.account.TokenAccountInfoDto;
 import kr.co.onehunnit.onhunnit.dto.token.TokenInfoDto;
 import kr.co.onehunnit.onhunnit.repository.AccountRepository;
 import kr.co.onehunnit.onhunnit.util.account.AccountUtil;
@@ -55,7 +52,7 @@ class OAuthServiceTest {
 		assertThat(accountRepository.count()).isEqualTo(1);
 		assertThat(accountRepository.findById(1L).get().getName()).isEqualTo(nickname);
 		assertThat(accountRepository.findById(1L).get().getEmail()).isEqualTo(email);
-		assertThat(accountRepository.findById(1L).get().getProfile_image()).isEqualTo(picture);
+		assertThat(accountRepository.findById(1L).get().getProfileImageUrl()).isEqualTo(picture);
 		assertThat(tokenInfoDto.getGrantType()).isEqualTo("Bearer");
 		assertThat(tokenInfoDto.getAccessToken()).isNotNull();
 		assertThat(tokenInfoDto.getRefreshToken()).isNotNull();


### PR DESCRIPTION
## 관련 이슈

https://onehunnit.atlassian.net/browse/OH-218

## 작업 내용
- 애플 소셜로그인 개발
- 소셜로그인 검증 로직
1. 클라이언트에서 수신한 id_token 분리(헤더, 페이로드, 서명)
2. 헤더에서 키 ID(kid) 추출
3. 추출한 키를 사용하여 Apple에서 공개 키를 가져옴
4. 공개키를 사용하여 id_token의 서명을 검증
5. 검증이 완료되면, 서버용 JWT 토큰 생성

## 참고사항
