### PR TITLE
ci(OK-89): merge 시 deploy 작업이 수행 안되는 문제 해결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,7 +62,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && github.event.pull_request.merged == true
 
     steps:
       - name: NCP login and docker image pull and run


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OK-89

## 작업 내용
- deploy job의 실행 조건 추가

## 참고사항
