### PR TITLE
ci(OK-89): merge 시 deploy 작업이 수행 안되는 문제 해결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,7 +60,7 @@ jobs:
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/fillbom
 
   deploy:
-    needs: build
+#    needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OK-89

## 작업 내용
- deploy job의 실행 조건 변경

## 참고사항
