### PR TITLE
fix(OK-99): 일기 작성 API 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
 
     // redis test
     implementation 'it.ozimov:embedded-redis:0.7.2'
+
+    implementation 'org.hibernate.common:hibernate-commons-annotations:6.0.6.Final'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Diary.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Diary.java
@@ -33,7 +33,8 @@ public class Diary extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String weather;
+	@Enumerated(EnumType.STRING)
+	private Weather weather;
 
 	@Enumerated(EnumType.STRING)
 	private Emotion emotion;

--- a/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Weather.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/domain/diary/Weather.java
@@ -1,0 +1,17 @@
+package kr.co.onehunnit.onhunnit.domain.diary;
+
+public enum Weather {
+
+	SUNNY("맑음"),
+	CLOUDY("구름"),
+	RAINY("비"),
+	SNOWY("눈"),
+	FOG("안개");
+
+	private final String description;
+
+	private Weather(String description) {
+		this.description = description;
+	}
+
+}

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/request/DiaryRequestDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/request/DiaryRequestDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.onehunnit.onhunnit.domain.diary.Diary;
 import kr.co.onehunnit.onhunnit.domain.diary.Emotion;
+import kr.co.onehunnit.onhunnit.domain.diary.Weather;
 import kr.co.onehunnit.onhunnit.domain.diarycontent.DiaryContent;
 import kr.co.onehunnit.onhunnit.domain.diarycontent.Type;
 import kr.co.onehunnit.onhunnit.domain.patient.Patient;
@@ -17,7 +18,7 @@ public class DiaryRequestDto {
 	@Schema(description = "내용 목록")
 	private List<DiaryContentDto> contents;
 
-	@Schema(description = "날씨")
+	@Schema(description = "날씨(SUNNY, CLOUDY, RAINY, SNOWY, FOG")
 	private String weather;
 
 	@Schema(description = "감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS")
@@ -57,7 +58,7 @@ public class DiaryRequestDto {
 
 	public Diary toEntity(DiaryRequestDto requestDto, Patient patient) {
 		return Diary.builder()
-			.weather(requestDto.getWeather())
+			.weather(Weather.valueOf(requestDto.getWeather()))
 			.emotion(Emotion.valueOf(requestDto.getEmotion()))
 			.shared(requestDto.isShared())
 			.audioUrl(requestDto.getAudioUrl())

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/request/DiaryRequestDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/request/DiaryRequestDto.java
@@ -18,7 +18,7 @@ public class DiaryRequestDto {
 	@Schema(description = "내용 목록")
 	private List<DiaryContentDto> contents;
 
-	@Schema(description = "날씨(SUNNY, CLOUDY, RAINY, SNOWY, FOG")
+	@Schema(description = "날씨(SUNNY, CLOUDY, RAINY, SNOWY, FOG)")
 	private String weather;
 
 	@Schema(description = "감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS")

--- a/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/response/DiaryDetailResponseDto.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/dto/diary/response/DiaryDetailResponseDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import kr.co.onehunnit.onhunnit.domain.diary.Diary;
 import kr.co.onehunnit.onhunnit.domain.diary.Emotion;
+import kr.co.onehunnit.onhunnit.domain.diary.Weather;
 import kr.co.onehunnit.onhunnit.domain.diarycontent.DiaryContent;
 import kr.co.onehunnit.onhunnit.domain.diarycontent.Type;
 import lombok.Builder;
@@ -17,7 +18,7 @@ public class DiaryDetailResponseDto {
 	private Long diaryId;
 	private Long patientId;
 	private List<ContentDto> contents;
-	private String weather;
+	private Weather weather;
 	private Emotion emotion;
 	private List<String> photos;
 	private LocalDateTime createdAt;

--- a/src/main/java/kr/co/onehunnit/onhunnit/service/DiaryService.java
+++ b/src/main/java/kr/co/onehunnit/onhunnit/service/DiaryService.java
@@ -50,7 +50,10 @@ public class DiaryService {
 		Long diaryId = diaryRepository.save(diary).getId();
 
 		saveDiaryContents(diaryRequestDto.getContents(), diary);
-		saveDiaryPhotos(diaryRequestDto.getPhotos(), diary);
+
+		if (diaryRequestDto.getPhotos() != null) {
+			saveDiaryPhotos(diaryRequestDto.getPhotos(), diary);
+		}
 
 		return diaryId;
 	}


### PR DESCRIPTION
## 관련 이슈
https://onehunnit.atlassian.net/browse/OK-99

## 작업 내용
- 사진이 없어도 일기 작성 가능하게 변경
- 일기의 날씨 필드 타입을 enum으로 변경(SUNNY, CLOUDY, RAINY, SNOWY, FOG)

## 참고사항
3월 25일 회의 요청사항